### PR TITLE
bump, fix the whole "not paying attention to range(s) thing"

### DIFF
--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_version.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_version.rb
@@ -1,7 +1,7 @@
 module Proxy
   module DHCP
     module Infoblox
-      VERSION = '0.0.2'
+      VERSION = '0.0.3'
     end
   end
 end


### PR DESCRIPTION
While working through an unrelated discovery issue, realized the unused_ip method wasn't doing anything with the from_ip_address and ip_ip_address parameters. 

This should fix that, however since the next_available_ip method for a network/range object can only take an *exclude* list, a little bit of hacky inversion is needed. Basically build a list of all ips, build a list of the range we *want*, then subtract to have a list of ip's we don't want, and pass that as the exclusion list. 

