### PR TITLE
Fix/amend README plus new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,40 @@
 # SmartProxyDhcpInfoblox
 
-*Introduction here*
-
-This plugin adds a new DHCP provider for managing records with Infoblox Servers
+This plugin adds a new DHCP provider for managing records with infoblox servers
 
 ## Installation
 
 See [How_to_Install_a_Smart-Proxy_Plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Install_a_Smart-Proxy_Plugin)
 for how to install Smart Proxy plugins
 
-This plugin is compatible with Smart Proxy 1.10 or higher.
+This plugin is compatible with Smart Proxy 1.11 or higher.
+
+When installing using "gem", make sure to install the bundle file:
+
+    echo "gem 'smart_proxy_dhcp_infoblox'" > /usr/share/foreman-proxy/bundler.d/dhcp_infoblox.rb
 
 ## Configuration
 
 To enable this DHCP provider, edit `/etc/foreman-proxy/settings.d/dhcp.yml` and set:
 
     :use_provider: dhcp_infoblox
+    :server: IP of infoblox server
+    :subnets: subnets you want to use (optional unless you set infoblox_subnets to false)
 
 Configuration options for this plugin are in `/etc/foreman-proxy/settings.d/dhcp_infoblox.yml` and include:
 
 * infoblox_user: API Username
 * infoblox_pw: API Password
-* infoblox_host: IP/URL to infoblox Server
+* record_type: host / fixed_address (see different record types chapter)
+* range: use infoblox ranges (true) or infoblox networks (false) to find the next free ip in your infoblox
+* infoblox_subnets: load all networks from infoblox (true + no subnets set in dhcp.yml) or load subnets from dhcp.yml only
+* restart_sleep: how many seconds do you want to sleep on restarting the infoblox services (only used when restart is enabled)
+* restart: restart services (true) or not (false) after adding/removing a dhcp record
 
-//// TEMP ////
-Add this to the Smart Proxy's bundler.d/Gemfile.local.rb configuration:
+## Different record types
+The main difference between host and fixed_address is that a host record already includes the dns records. It's an infoblox object that includes dhcp/a record/ptr records. If you use the host objects there is no need to use a dns smart proxy. Everything gets handled inside the dhcp smart proxy. This does however limit functionality. You can't delete conflicting records or you can't change dns names using foreman gui. Beware when editing host objects manually in infoblox, once you delete a host in foreman all associated host objects get deleted.
 
-  gem 'smart_proxy_dhcp_infoblox', :path => '/path/tosmart_proxy_dhcp_infoblox'
+If you chose to use fixed_address you'll need to use the infoblox dns smart proxy (https://github.com/theforeman/smart_proxy_dns_infoblox) if you want to manage dns records.
 
 ## Contributing
 

--- a/config/dhcp_infoblox.yml
+++ b/config/dhcp_infoblox.yml
@@ -12,3 +12,7 @@
 :wapi_version: '2.0'
 #Use  pre-definded ranges in networks to find available IP's
 :range: false
+#Load subnets from Infoblox, if false subnets from dhcp.yml are loaded
+#:infoblox_subnets: true
+#:restart_sleep: 15
+#:restart: true

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
@@ -2,17 +2,18 @@ require 'smart_proxy_dhcp_infoblox/dhcp_infoblox_version'
 
 module Proxy::DHCP::Infoblox
   class Plugin < ::Proxy::Provider
-    plugin :dhcp_infoblox, ::Proxy::DHCP::Infoblox::VERSION, :provider_class => "::Proxy::DHCP::Infoblox::Provider"
+    plugin :dhcp_infoblox, ::Proxy::DHCP::Infoblox::VERSION
 
     # Settings listed under default_settings are required.
     # An exception will be raised if they are initialized with nil values.
     # Settings not listed under default_settings are considered optional and by default have nil value.
     default_settings :infoblox_user => 'infoblox',
      :infoblox_pw => 'infoblox',
-     :infoblox_host => 'infoblox.my.domain',
      :record_type => 'host',
      :wapi_version => '2.0',
-     :range => false
+     :range => false,
+     :infoblox_subnets => false,
+     :restart => false
 
     requires :dhcp, '>= 1.11'
 

--- a/test/dhcp_infoblox_record_test.rb
+++ b/test/dhcp_infoblox_record_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'dns/dns_plugin'
+require 'dhcp/dhcp_plugin'
 require 'smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin'
 require 'smart_proxy_dhcp_infoblox/dhcp_infoblox_main'
 
@@ -7,13 +7,13 @@ require 'smart_proxy_dhcp_infoblox/dhcp_infoblox_main'
 class InfobloxRecordTest < Test::Unit::TestCase
 
   def test_default_settings
-    Proxy::Dns::Infoblox::Plugin.load_test_settings({})
-    assert_equal "default_value", Proxy::Dns::Nsupdate::Plugin.settings.required_setting
-    assert_equal "/must/exist", Proxy::Dns::Nsupdate::Plugin.settings.required_path
+    Proxy::DHCP::Infoblox::Plugin.load_test_settings({})
+    assert_equal "default_value", Proxy::DHCP::Nsupdate::Plugin.settings.required_setting
+    assert_equal "/must/exist", Proxy::DHCP::Nsupdate::Plugin.settings.required_path
   end
 
   def test_initialized_correctly
-    Proxy::Dns::Infoblox::Plugin.load_test_settings(:example_setting => 'a_value',
+    Proxy::DHCP::Infoblox::Plugin.load_test_settings(:example_setting => 'a_value',
                                                           :required_setting => 'required_setting',
                                                           :optional_path => '/some/path',
                                                           :required_path => '/required/path')
@@ -38,7 +38,7 @@ class InfobloxRecordTest < Test::Unit::TestCase
     # Use mocha to expect any calls to backend services to prevent creating real records
     #   MyService.expects(:create).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(false)
 
-    assert_raise(Proxy::Dns::Collision) { klass.new.create_a_record('test.example.com', '10.1.1.1') }
+    assert_raise(Proxy::DHCP::Collision) { klass.new.create_a_record('test.example.com', '10.1.1.1') }
   end
 
   # Test PTR record creation
@@ -54,7 +54,7 @@ class InfobloxRecordTest < Test::Unit::TestCase
     # Use mocha to expect any calls to backend services to prevent creating real records
     #   MyService.expects(:create_reverse).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(false)
 
-    assert_raise(Proxy::Dns::Collision) { klass.new.create_ptr_record('test.example.com', '10.1.1.1') }
+    assert_raise(Proxy::DHCP::Collision) { klass.new.create_ptr_record('test.example.com', '10.1.1.1') }
   end
 
   # Test A record removal
@@ -70,7 +70,7 @@ class InfobloxRecordTest < Test::Unit::TestCase
     # Use mocha to expect any calls to backend services to prevent deleting real records
     #   MyService.expects(:delete).with(:name => 'test.example.com').returns(false)
 
-    assert_raise(Proxy::Dns::NotFound) { assert klass.new.remove_a_record('test.example.com') }
+    assert_raise(Proxy::DHCP::NotFound) { assert klass.new.remove_a_record('test.example.com') }
   end
 
   # Test PTR record removal
@@ -86,10 +86,10 @@ class InfobloxRecordTest < Test::Unit::TestCase
     # Use mocha to expect any calls to backend services to prevent deleting real records
     #   MyService.expects(:delete).with(:ip => '10.1.1.1').returns(false)
 
-    assert_raise(Proxy::Dns::NotFound) { assert klass.new.remove_ptr_record('1.1.1.10.in-addr.arpa') }
+    assert_raise(Proxy::DHCP::NotFound) { assert klass.new.remove_ptr_record('1.1.1.10.in-addr.arpa') }
   end
 
   def klass
-    Proxy::Dns::Infoblox::Record
+    Proxy::DHCP::Infoblox::Record
   end
 end


### PR DESCRIPTION
* optional automatical restart of service after add
* optional wait time after restarting services (useful if you have a grid)
* allow to not load all subnets from infoblox (huge speed increase if you have a lot of networks)
* unused_ip now checks if the from and to ip address fields are set, those are optional in foreman
* deleting host object now actually deletes it