### PR TITLE
Fix typos in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ To enable this DHCP provider, edit `/etc/foreman-proxy/settings.d/dhcp.yml` and 
 Configuration options for this plugin are in `/etc/foreman-proxy/settings.d/dhcp_infoblox.yml` and include:
 
 * username: API Username
-* passowrd: API Password
+* password: API Password
 * record_type: host / fixedaddress (see different record types chapter)
-* use_range: use infoblox ranges (true) or infoblox networks (false) to find the next free ip in your infoblox
+* use_ranges: use infoblox ranges (true) or infoblox networks (false) to find the next free ip in your infoblox
 
 ## Different record types
 The main difference between host and fixedaddress is that a host record already includes the dns records. It's an infoblox object that includes dhcp/a record/ptr records. If you use the host objects there is no need to use a dns smart proxy. Everything gets handled inside the dhcp smart proxy. This does however limit functionality. You can't delete conflicting records or you can't change dns names using foreman gui. Beware when editing host objects manually in infoblox, once you delete a host in foreman all associated host objects get deleted.


### PR DESCRIPTION
There were some typos in the config options in the README.
I stumbled over the use_range when trying out the plugin.
