### PR TITLE
Fixes #18300 - removed unused load_ methods

### DIFF
--- a/lib/smart_proxy_dhcp_infoblox/common_crud.rb
+++ b/lib/smart_proxy_dhcp_infoblox/common_crud.rb
@@ -74,16 +74,14 @@ module ::Proxy::DHCP::Infoblox
       return nil if host.mac.nil? || host.mac.empty?
 
       opts = { :hostname => name }
-      opts[:mac] = host.mac
-      opts[:ip] = host.ipv4addr
       opts[:deleteable] = true
       # TODO: nextserver, use_nextserver, bootfile, and use_bootfile attrs exist but are not available in the Fixedaddress model
       # Might be useful to extend the model to include these
       opts[:nextServer] = host.nextserver if (host.respond_to?(:use_nextserver) && host.use_nextserver)
       opts[:filename] = host.bootfile if (host.respond_to?(:use_bootfile) && host.use_bootfile)
-      opts[:subnet] = ::Proxy::DHCP::Subnet.new(full_subnet_address.split('/').first, cidr_to_ip_mask(cidr_to_i(full_subnet_address.split('/').last)))
+      subnet = ::Proxy::DHCP::Subnet.new(full_subnet_address.split('/').first, cidr_to_ip_mask(cidr_to_i(full_subnet_address.split('/').last)))
 
-      Proxy::DHCP::Reservation.new(opts)
+      Proxy::DHCP::Reservation.new(name, host.ipv4addr, host.mac, subnet, opts)
     end
   end
 end

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
@@ -18,8 +18,6 @@ module Proxy::DHCP::Infoblox
     end
 
     def find_subnet(address);::Proxy::DHCP::Subnet.new(address, '255.255.255.0'); end
-    def load_subnets; end
-    def load_subnet_data(_); end
 
     def subnets
       ::Infoblox::Network.all(connection).map do |network|

--- a/test/host_and_fixedaddress_crud_test.rb
+++ b/test/host_and_fixedaddress_crud_test.rb
@@ -101,10 +101,9 @@ class HostCrudTest < Test::Unit::TestCase
         :ipv4addrs => [{:ipv4addr => @ip, :mac => '00:01:02:03:05:07', :nextserver => @nextserver, :use_nextserver => true,
                         :bootfile => @filename, :use_bootfile => true, :configure_for_dhcp => true}])
 
-    @reservation = ::Proxy::DHCP::Reservation.new(
-        :hostname => @hostname, :mac => @mac, :ip => @ip, :nextServer => @nextserver,
-        :filename => @filename, :deleteable => true,
-        :subnet => ::Proxy::DHCP::Subnet.new(@subnet_ip, '255.255.255.0'))
+    @reservation = ::Proxy::DHCP::Reservation.new(@hostname, @ip, @mac, ::Proxy::DHCP::Subnet.new(@subnet_ip, '255.255.255.0'),
+                                                  :hostname => @hostname, :nextServer => @nextserver, :filename => @filename,
+                                                  :deleteable => true)
   end
 
   def test_all_hosts
@@ -162,9 +161,8 @@ class FixedaddressCrudTest < Test::Unit::TestCase
         :name => 'another.test.com',
         :ipv4addr => @ip, :mac => '00:01:02:03:05:07')
 
-    @reservation = ::Proxy::DHCP::Reservation.new(
-        :hostname => @hostname, :mac => @mac, :ip => @ip, :deleteable => true,
-        :subnet => ::Proxy::DHCP::Subnet.new(@subnet_ip, '255.255.255.0'))
+    @reservation = ::Proxy::DHCP::Reservation.new(@hostname, @ip, @mac, ::Proxy::DHCP::Subnet.new(@subnet_ip, '255.255.255.0'),
+                                                  :deleteable => true, :hostname => @hostname)
   end
 
   def test_all_hosts

--- a/test/infoblox_provider_test.rb
+++ b/test/infoblox_provider_test.rb
@@ -52,11 +52,8 @@ class InfobloxProviderTest < Test::Unit::TestCase
     @crud.stubs(:del_record)
     @provider.stubs(:full_network_address)
     @restart_grid.expects(:try_restart)
-    @provider.del_record(@subnet,
-                         ::Proxy::DHCP::Record.new(:name => 'test',
-                                                   :ip => '192.168.42.1',
-                                                   :mac => '00:01:02:03:04:05',
-                                                   :subnet => ::Proxy::DHCP::Subnet.new('192.168.42.0', '255.255.255.0')))
+    @provider.del_record(@subnet, ::Proxy::DHCP::Record.new('192.168.42.1', '00:01:02:03:04:05',
+                                                            ::Proxy::DHCP::Subnet.new('192.168.42.0', '255.255.255.0')))
   end
 
   def test_del_record_by_mac_restarts_grid


### PR DESCRIPTION
And fixed failing tests. This is dependent on https://github.com/theforeman/smart-proxy/pull/502.