### PR TITLE
Add support for the Infoblox lease object

### DIFF
--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
@@ -32,7 +32,7 @@ module Proxy::DHCP::Infoblox
     end
 
     def all_leases(network_address)
-      crud.all_leases(full_network_address(network_address))
+      crud.all_leases(full_network_address(network_address), find_subnet(network_address))
     end
 
     def find_record(subnet_address, an_address)


### PR DESCRIPTION
This requires a newer version of the infoblox gem that adds the object on their side, another possibility could be to write a lease object directly in the smart_proxy code. Something like;

```ruby
require 'infoblox/resource'

module ::Proxy::DHCP::Infoblox
  class Lease < ::Infoblox::Resource
    remote_attr_reader :address,
                       :binding_state,
                       :client_hostname,
                       :ends,
                       :hardware,
                       :network,
                       :starts

    wapi_object 'lease'
  end
```

Then it could be used without bumping the gem version two majors.