### PR TITLE
Support boot information in fixedaddress

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'infoblox', '>= 0.4.1'
+gem 'infoblox', '>= 2.0.4'
 if RUBY_VERSION < '2.0.0'
   gem 'json', '< 2.0.0', :require => false
 end

--- a/lib/smart_proxy_dhcp_infoblox/fixed_address_crud.rb
+++ b/lib/smart_proxy_dhcp_infoblox/fixed_address_crud.rb
@@ -47,12 +47,10 @@ module ::Proxy::DHCP::Infoblox
       host.name = options[:hostname]
       host.ipv4addr = options[:ip]
       host.mac = options[:mac]
-      # TODO: nextserver, use_nextserver, bootfile, and use_bootfile attrs exist but are not available in the model
-      # Might be useful to extend the model to include these
-      #host.nextserver = options[:nextServer]
-      #host.use_nextserver = true
-      #host.bootfile = options[:filename]
-      #host.use_bootfile = true
+      host.nextserver = options[:nextServer]
+      host.use_nextserver = true
+      host.bootfile = options[:filename]
+      host.use_bootfile = true
       host
     end
   end

--- a/test/host_and_fixedaddress_crud_test.rb
+++ b/test/host_and_fixedaddress_crud_test.rb
@@ -177,10 +177,10 @@ class FixedaddressCrudTest < Test::Unit::TestCase
     assert_equal @host.name, built.name
     assert_equal @host.ipv4addr, built.ipv4addr
     assert_equal @host.mac, built.mac
-#    assert @host.nextserver, built.nextserver
-#    assert built.use_nextserver
-#    assert_equal @host.bootfile, built.bootfile
-#    assert built.use_bootfile
+    assert_equal @nextserver, built.nextserver
+    assert built.use_nextserver
+    assert_equal @filename, built.bootfile
+    assert built.use_bootfile
   end
 
   def test_add_record_with_collision


### PR DESCRIPTION
This requires an update of the Infoblox gem to one that adds the
required attributes.

It could also probably be done by creating an inline entry instead of upgrading the gem, something like;
```ruby
module ::Proxy::DHCP::Infoblox
  class FixedAddressCRUD < CommonCRUD
# ...
    def build_host(options)
      host = Fixedaddress.new(:connection => @connection)
      host.name = options[:hostname]
      host.ipv4addr = options[:ip]
      host.mac = options[:mac]
      host.nextserver = options[:nextServer]
      host.use_nextserver = true
      host.bootfile = options[:filename]
      host.use_bootfile = true
      host
    end

    # Extended entry record
    class Fixedaddress < ::Infoblox::Resource
      remote_attr_accessor :extattrs,
                           :ipv4addr,
                           :mac,
                           :name,
                           :network,
                           :network_view,
                           :options,
                           :match_client,
                           :nextserver,
                           :use_nextserver,
                           :bootfile,
                           :use_bootfile,
                           :comment

      wapi_object 'fixedaddress'
    end
  end
end
```