### PR TITLE
Enable SSL cert verify by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,43 @@ The main difference between host and fixedaddress is that a host record already 
 
 If you chose to use fixedaddress you'll need to use the infoblox dns smart proxy (https://github.com/theforeman/smart_proxy_dns_infoblox) if you want to manage dns records.
 
+## SSL
+
+The plugin enforces HTTPS server certificate verification. Follow a standard CA cert installation procedure for your operating system. It's possible to either download the server certificate from Infoblox web UI or use openssl command to extract it from server response. Here are example steps for Red Hat compatible systems:
+
+```
+# update-ca-trust enable
+# openssl s_client -showcerts -connect 192.168.201.2:443 </dev/null | openssl x509 -text >/etc/pki/ca-trust/source/anchors/infoblox.crt
+# update-ca-trust extract
+```
+
+For Debian-compatible systems:
+
+```
+# openssl s_client -showcerts -connect 192.168.201.2:443 </dev/null | openssl x509 -text >/usr/local/share/ca-certificates/infoblox.crt
+# update-ca-certificates
+```
+
+To test the CA certificate, a simple curl query can be used. This is a positive test:
+
+```
+# curl -u admin:infoblox https://192.168.201.2/wapi/v2.0/network
+[
+    {
+        "_ref": "network/ZG5zLm5ldHdvcmskMTkyLjE2OC4yMDIuMC8yNC8w:192.168.202.0/24/default",
+        "network": "192.168.202.0/24",
+        "network_view": "default"
+    }
+]
+```
+
+And a negative one:
+
+```
+# curl -u admin:infoblox https://192.168.201.2/wapi/v2.0/network
+curl: (60) SSL certificate problem: self signed certificate
+```
+
 ## Contributing
 
 Fork and send a Pull Request. Thanks!

--- a/lib/smart_proxy_dhcp_infoblox/plugin_configuration.rb
+++ b/lib/smart_proxy_dhcp_infoblox/plugin_configuration.rb
@@ -16,7 +16,7 @@ module Proxy::DHCP::Infoblox
       c.dependency :connection, (lambda do
                                   ::Infoblox.wapi_version = '2.0'
                                   ::Infoblox::Connection.new(:username => settings[:username] ,:password => settings[:password],
-                                                             :host => settings[:server], :ssl_opts => {:verify => false})
+                                                             :host => settings[:server], :ssl_opts => { :verify => true }, :logger => ::Proxy::LogBuffer::Decorator.instance)
                                 end)
 
 

--- a/test/plugin_configuration_test.rb
+++ b/test/plugin_configuration_test.rb
@@ -33,7 +33,7 @@ class InfobloxDhcpProductionWiringTest < Test::Unit::TestCase
     assert_equal 'https://127.0.0.1', connection.host
     assert_equal 'user', connection.username
     assert_equal 'password', connection.password
-    assert_equal({:verify => false}, connection.ssl_opts)
+    assert_equal({:verify => true}, connection.ssl_opts)
   end
 
   def test_unused_ips_configuration


### PR DESCRIPTION
SSL verification should be turned on by default. The patch comes with instructions how to set SSL properly. It also configures logging properly, the infoblox gem passes this to faraday gem which adds nice logging of all requests via INFO level and all request and response headers and body via DEBUG level.

Also available as DNS counterpart: https://github.com/theforeman/smart_proxy_dns_infoblox/pull/18