### PR TITLE
Made fixedaddress the default mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,12 +3,12 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.0
 
+Metrics:
+  Enabled: false
+
 # There's if statement in the Gemfile
 Bundler/DuplicatedGem:
   Enabled: false
-
-Metrics/LineLength:
-  Max: 200
 
 Layout/LeadingCommentSpace:
   Enabled: false
@@ -39,15 +39,8 @@ Style/NumericPredicate:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Metrics/AbcSize:
-  Enabled: false
-
 Style/SymbolArray:
   Enabled: false
-
-Metrics/ClassLength:
-  Exclude:
-    - 'test/**/*'
 
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/config/dhcp_infoblox.yml.example
+++ b/config/dhcp_infoblox.yml.example
@@ -1,15 +1,20 @@
 ---
-#
 # Configuration file for 'dhcp_infoblox' dhcp provider
 #
-# use :server setting in dhcp.yml if you are managing a dhcp server which is not localhost
-# use :subnets setting in dhcp.yml if you want to restrict subnets available to smart-proxy
-#
-:username: "infoblox"
+# Use :server setting in dhcp.yml if you are managing a dhcp server which is not localhost.
+# Use :subnets setting in dhcp.yml if you want to restrict subnets available to smart-proxy.
+
+# Credentials for Infoblox API, make sure the DHCP Role is assigned
+:username: "admin"
 :password: "infoblox"
-#
-# Record type to manage: can be "host" or "fixedaddress"
-#
-:record_type: 'host'
-#:dns_view: 'non-default'
-#:network_view: 'another-non-default'
+
+# Record type to manage: can be "host" or "fixedaddress". The latter is recommended as
+# "host" setting will cause conflicts when using Infoblox DNS smart proxy plugin. When
+# using "host" setting make sure domain exists in Infoblox.
+:record_type: 'fixedaddress'
+
+# View used for fixedaddress record type.
+#:network_view: 'default'
+
+# View used for host record type, usually 'default.myview' for custom names.
+#:dns_view: 'default'

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
@@ -92,7 +92,7 @@ module Proxy::DHCP::Infoblox
     def find_network(network_address)
       network = ::Infoblox::Network.find(connection, 'network' => network_address, 'network_view' => network_view,
                                          '_max_results' => 1).first
-      raise "Subnet #{network_address} not found" if network.nil?
+      raise "Subnet #{network_address} not found in network view #{network_view}" if network.nil?
       network
     end
 

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
@@ -2,7 +2,7 @@ module Proxy::DHCP::Infoblox
   class Plugin < ::Proxy::Provider
     plugin :dhcp_infoblox, ::Proxy::DHCP::Infoblox::VERSION
 
-    default_settings :record_type => 'host', :dns_view => "default", :network_view => "default", :blacklist_duration_minutes => 30 * 60
+    default_settings :record_type => 'fixedaddress', :dns_view => "default", :network_view => "default", :blacklist_duration_minutes => 30 * 60
     validate_presence :username, :password
 
     requires :dhcp, '>= 1.13'


### PR DESCRIPTION
After more testing I think that 'fixedaddress' fits better to Foreman (with a separate DNS provider) and it's more safer too (no conflict errors). Therefore I propose it for the default mode.