### PR TITLE
Fixes #27060 - post-restart grid delay

### DIFF
--- a/config/dhcp_infoblox.yml.example
+++ b/config/dhcp_infoblox.yml.example
@@ -18,3 +18,7 @@
 
 # View used for host record type, usually 'default.myview' for custom names.
 #:dns_view: 'default'
+
+# Number of seconds to wait after successful Grid restart (make sure to increase Foreman and CLI timeouts).
+# Set to 0 to disable the delay.
+#:wait_after_restart: 10

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
@@ -2,7 +2,12 @@ module Proxy::DHCP::Infoblox
   class Plugin < ::Proxy::Provider
     plugin :dhcp_infoblox, ::Proxy::DHCP::Infoblox::VERSION
 
-    default_settings :record_type => 'fixedaddress', :dns_view => "default", :network_view => "default", :blacklist_duration_minutes => 30 * 60
+    default_settings :record_type => 'fixedaddress',
+        :dns_view => "default",
+        :network_view => "default",
+        :blacklist_duration_minutes => 30 * 60,
+        :wait_after_restart => 10
+
     validate_presence :username, :password
 
     requires :dhcp, '>= 1.13'

--- a/lib/smart_proxy_dhcp_infoblox/grid_restart.rb
+++ b/lib/smart_proxy_dhcp_infoblox/grid_restart.rb
@@ -1,6 +1,6 @@
 module ::Proxy::DHCP::Infoblox
   class GridRestart
-    MAX_ATTEMPTS = 3
+    MAX_ATTEMPTS = 5
 
     include ::Proxy::Log
     attr_reader :connection
@@ -10,21 +10,32 @@ module ::Proxy::DHCP::Infoblox
     end
 
     def try_restart
-      logger.debug 'Restarting grid.'
+      logger.info 'Restarting Infoblox Grid'
 
+      delay = Proxy::DHCP::Infoblox::Plugin.settings.wait_after_restart.to_i
       MAX_ATTEMPTS.times do |tries|
+        if restart
+          if delay > 0
+            logger.info "Starting post-restart delay of #{delay} seconds..."
+            sleep delay
+            logger.debug "Post-restart delay done"
+          end
+          return
+        end
         sleep tries
-        return if restart
       end
 
-      logger.info 'Restarting Grid failed.'
+      logger.warn 'Restarting Infoblox Grid failed, giving up'
       false
     end
+
+    private
 
     def restart
       (@grid ||= ::Infoblox::Grid.get(@connection).first).restartservices
       true
     rescue Exception => e
+      logger.warn "Error during Grid restart: #{e}"
       false
     end
   end

--- a/test/plugin_configuration_test.rb
+++ b/test/plugin_configuration_test.rb
@@ -12,7 +12,11 @@ require 'smart_proxy_dhcp_infoblox/dhcp_infoblox_main'
 
 class PluginDefaultConfigurationTest < Test::Unit::TestCase
   def test_default_settings
-    assert_equal({ :record_type => 'host', :blacklist_duration_minutes => 30 * 60, :dns_view => "default", :network_view => "default" },
+    assert_equal({ :record_type => 'fixedaddress',
+      :blacklist_duration_minutes => 30 * 60,
+      :wait_after_restart => 10,
+      :dns_view => "default",
+      :network_view => "default" },
                  Proxy::DHCP::Infoblox::Plugin.default_settings)
   end
 end
@@ -21,8 +25,8 @@ class InfobloxDhcpProductionWiringTest < Test::Unit::TestCase
   def setup
     @network_view = "network_view"
     @dns_view = "dns_view"
-    @settings = { :username => 'user', :password => 'password', :server => '127.0.0.1', :record_type => 'host',
-                 :subnets => ['1.1.1.0/255.255.255.0'], :blacklist_duration_minutes => 300,
+    @settings = { :username => 'user', :password => 'password', :server => '127.0.0.1', :record_type => 'fixedaddress',
+                 :subnets => ['1.1.1.0/255.255.255.0'], :blacklist_duration_minutes => 300, :wait_after_restart => 1,
                  :dns_view => @dns_view, :network_view => @network_view }
     @container = ::Proxy::DependencyInjection::Container.new
     Proxy::DHCP::Infoblox::PluginConfiguration.new.load_dependency_injection_wirings(@container, @settings)
@@ -66,7 +70,7 @@ class InfobloxDhcpProductionWiringTest < Test::Unit::TestCase
     assert_not_nil provider.free_ips
     assert_equal @network_view, provider.network_view
     assert provider.managed_subnets.include?('1.1.1.0/255.255.255.0')
-    assert provider.crud.instance_of?(::Proxy::DHCP::Infoblox::HostIpv4AddressCRUD)
+    assert provider.crud.instance_of?(::Proxy::DHCP::Infoblox::FixedAddressCRUD)
   end
 
   def test_provider_configuration_with_fixedaddress_crud


### PR DESCRIPTION
Also fixes "fixedaddress" default setting from my previous PR. Tests do not run automatically here, travis just runs rubocop.