### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+---
+name: Release
+
+on:
+  create:
+    ref_type: tag
+
+jobs:
+  release:
+    name: Release gem
+    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
+    with:
+      allowed_owner: theforeman
+    secrets:
+      api_key: ${{ secrets.RUBYGEM_API_KEY }}


### PR DESCRIPTION
This workflow builds and pushes the gem to Rubygems using a shared action. It triggers when a tag is pushed to theforeman namespace.