### PR TITLE
Remove redundant RuboCop disabling & fix Performance/RegexpMatch cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,14 +23,6 @@ Layout/LeadingCommentSpace:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
-# Don't prefer is_a? over kind_of?
-Style/ClassCheck:
-  Enabled: false
-
-# Don't enforce certain methods, e.g. detect over find
-Style/CollectionMethods:
-  Enabled: false
-
 # Don't enforce documentation
 Style/Documentation:
   Enabled: false
@@ -49,22 +41,10 @@ Style/FrozenStringLiteralComment:
 Style/SymbolArray:
   Enabled: false
 
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
 Lint/AssignmentInCondition:
   Enabled: false
 
-Security/Eval:
-  Enabled: false
-
 Lint/RescueException:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
   Enabled: false
 
 Style/SymbolProc:
@@ -96,12 +76,6 @@ Style/TernaryParentheses:
 Style/InverseMethods:
   Enabled: false
 
-Bundler/OrderedGems:
-  Enabled: false
-
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
 Layout/DotPosition:
   Enabled: false
 
@@ -111,9 +85,6 @@ Style/IfUnlessModifier:
 Style/ConditionalAssignment:
   Enabled: false
 
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-
 Style/ParenthesesAroundCondition:
   Enabled: false
 
@@ -121,13 +92,6 @@ Layout/HashAlignment:
   Enabled: false
 
 Layout/ParameterAlignment:
-  Enabled: false
-
-# disabled until we can configure "+" as concat sign
-Style/LineEndConcatenation:
-  Enabled: false
-
-Style/ParallelAssignment:
   Enabled: false
 
 Performance/RegexpMatch:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,9 +94,6 @@ Layout/HashAlignment:
 Layout/ParameterAlignment:
   Enabled: false
 
-Performance/RegexpMatch:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/lib/smart_proxy_dhcp_infoblox/common_crud.rb
+++ b/lib/smart_proxy_dhcp_infoblox/common_crud.rb
@@ -35,7 +35,7 @@ module ::Proxy::DHCP::Infoblox
     end
 
     def find_record(subnet_address, an_address)
-      return find_record_by_ip(subnet_address, an_address) if Resolv::IPv4::Regex =~ an_address
+      return find_record_by_ip(subnet_address, an_address) if Resolv::IPv4::Regex.match?(an_address)
 
       find_record_by_mac(subnet_address, an_address)
     end


### PR DESCRIPTION
This works towards a smaller RuboCop config file.